### PR TITLE
Relax restrictions of h5py

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,6 +1,11 @@
 name: pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - dev
+  pull_request:
 
 jobs:
   test-job:

--- a/cadet/__init__.py
+++ b/cadet/__init__.py
@@ -1,6 +1,6 @@
 name = 'CADET-python'
 
-__version__ = "0.14"
+__version__ = "0.14.1"
 
 from .cadet import H5
 from .cadet import Cadet

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     install_requires=[
           'addict',
           'numpy',
-          'h5py <= 3.6.0',
+          'h5py',
           'filelock'
       ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
     
 setuptools.setup(
     name="CADET-Python",
-    version="0.14",
+    version="0.14.1",
     author="William Heymann",
     author_email="w.heymann@fz-juelich.de",
     description="CADET is a python interface to the CADET chromatography simulator",


### PR DESCRIPTION
@Immudzen / @ronald-jaepel could you test if it's possible to install this on your machine? At some points we had some issues with hdf5/h5py on Windows so we decided to limit h5py<=3.6.0 However, there now seems to be an issue with h5py==3.6.0 on Python 3.11 which I would like to include in CADET-Process v0.8.0